### PR TITLE
[#1] NetworkManager 구현

### DIFF
--- a/VocaVocca.xcodeproj/project.pbxproj
+++ b/VocaVocca.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BAB189F22D2E7F6500E4DF7C /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = BAB189F12D2E7F6500E4DF7C /* Config.xcconfig */; };
 		F2ED388D2D2E111F005B7BC0 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = F2ED388C2D2E111F005B7BC0 /* .gitignore */; };
 		F2ED38972D2E13A8005B7BC0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F2ED38962D2E13A8005B7BC0 /* SnapKit */; };
 		F2ED389A2D2E16AF005B7BC0 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F2ED38992D2E16AF005B7BC0 /* RxSwift */; };
@@ -14,8 +15,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BAB189962D2E7D4300E4DF7C /* VocaVocca.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VocaVocca.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BAB189F12D2E7F6500E4DF7C /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		F2ED388C2D2E111F005B7BC0 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
-		F2ED38912D2E121A005B7BC0 /* VocaVocca.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = VocaVocca.app; path = "/Users/eden/Desktop/iOS/VocaVocca/build/Debug-iphoneos/VocaVocca.app"; sourceTree = "<absolute>"; };
 		F2ED389C2D2E16E7005B7BC0 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -57,9 +59,11 @@
 		F2ED383B2D2E10D8005B7BC0 = {
 			isa = PBXGroup;
 			children = (
+				BAB189F12D2E7F6500E4DF7C /* Config.xcconfig */,
 				F2ED38462D2E10D8005B7BC0 /* VocaVocca */,
 				F2ED388C2D2E111F005B7BC0 /* .gitignore */,
 				F2ED389B2D2E16E7005B7BC0 /* Frameworks */,
+				BAB189962D2E7D4300E4DF7C /* VocaVocca.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -95,7 +99,7 @@
 				F2ED38992D2E16AF005B7BC0 /* RxSwift */,
 			);
 			productName = VocaVocca;
-			productReference = F2ED38912D2E121A005B7BC0 /* VocaVocca.app */;
+			productReference = BAB189962D2E7D4300E4DF7C /* VocaVocca.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -141,6 +145,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BAB189F22D2E7F6500E4DF7C /* Config.xcconfig in Resources */,
 				F2ED388D2D2E111F005B7BC0 /* .gitignore in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -160,6 +165,7 @@
 /* Begin XCBuildConfiguration section */
 		F2ED38582D2E10D8005B7BC0 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BAB189F12D2E7F6500E4DF7C /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/VocaVocca/Model/Language.swift
+++ b/VocaVocca/Model/Language.swift
@@ -1,0 +1,24 @@
+//
+//  Language.swift
+//  VocaVocca
+//
+//  Created by mun on 1/9/25.
+//
+
+enum Language {
+    case english
+    case chinese
+    case japanese
+    case german
+    case spanish
+
+    var title: String {
+        switch self {
+        case .english: return "EN"
+        case .chinese: return "CH"
+        case .japanese: return "JA"
+        case .german: return "GE"
+        case .spanish: return "SP"
+        }
+    }
+}

--- a/VocaVocca/Model/Language.swift
+++ b/VocaVocca/Model/Language.swift
@@ -5,9 +5,9 @@
 //  Created by mun on 1/9/25.
 //
 
-enum Language {
-    case english
-    case chinese
+enum Language: Int {
+    case english = 0
+    case chinese // 중국어(번체)
     case japanese
     case german
     case spanish
@@ -15,10 +15,10 @@ enum Language {
     var title: String {
         switch self {
         case .english: return "EN"
-        case .chinese: return "CH"
+        case .chinese: return "ZH"
         case .japanese: return "JA"
-        case .german: return "GE"
-        case .spanish: return "SP"
+        case .german: return "DE"
+        case .spanish: return "ES"
         }
     }
 }

--- a/VocaVocca/Model/NetworkManager.swift
+++ b/VocaVocca/Model/NetworkManager.swift
@@ -6,3 +6,110 @@
 //
 
 import Foundation
+import RxSwift
+
+class NetworkManager {
+
+    static let shared = NetworkManager()
+    private init() {}
+
+    func fetch<T: Decodable>(customURLComponents: CustomURLComponents) -> Single<T> {
+        return Single.create { [weak self] single in
+
+            guard let self = self,
+                  let url = self.createURL(customURLComponents) else {
+                single(.failure(NetworkError.invalidURL)) // URL 에러 전달
+                return Disposables.create()
+            }
+
+            let session = URLSession(configuration: .default)
+            // 네트워크 요청
+            session.dataTask(with: URLRequest(url: url)) { data, response, error in
+                if let error = error {
+                    single(.failure(error)) // 에러 전달
+                    return
+                }
+
+                guard let data = data else {
+                    single(.failure(NetworkError.noData)) // 데이터 에러 전달
+                    return
+                }
+
+                guard let response = response as? HTTPURLResponse,
+                      (200..<300).contains(response.statusCode) else {
+                    single(.failure(NetworkError.dataFetchFail)) // 데이터패치 에러 전달
+                    return
+                }
+
+                do {
+                    let decodedData = try JSONDecoder().decode(T.self, from: data)
+                    single(.success(decodedData)) // 성공 이벤트 전달
+                } catch {
+                    single(.failure(NetworkError.decodingFail)) // 디코딩 에러 전달
+                }
+            }.resume()
+
+            return Disposables.create()
+        }
+    }
+
+    // URL 생성 메서드
+    private func createURL(_ customURLComponents: CustomURLComponents) -> URL? {
+
+        var urlComponents = URLComponents()
+        var queryItems = [URLQueryItem]()
+
+        urlComponents.scheme = customURLComponents.scheme
+        urlComponents.host = customURLComponents.host
+        urlComponents.path = customURLComponents.path
+
+        customURLComponents.querys.forEach { key, value in
+            queryItems.append(URLQueryItem(name: key, value: value))
+        }
+
+        urlComponents.queryItems = queryItems
+
+        //URL 생성
+        guard let url = urlComponents.url else {
+            return nil
+        }
+
+        return url
+    }
+}
+
+extension NetworkManager {
+    // 네트워크 에러
+    enum NetworkError: Error {
+        case invalidURL
+        case noData
+        case dataFetchFail
+        case decodingFail
+    }
+
+    // URLComponents
+    enum CustomURLComponents {
+        case translation(text: String, lang: Language)
+
+        var scheme: String {
+            return "https"
+        }
+        var host: String {
+            return "api-free.deepl.com"
+        }
+        var path: String {
+            return "/v2/translate"
+        }
+        var querys: [String: String] {
+            switch self {
+            case .translation(let text, let lang):
+                return [
+                    "text": text,
+                    "source_lang": lang.title,
+                    "target_lang": "KO",
+                    "auth_key": Bundle.main.infoDictionary?["APIKey"] as? String ?? ""
+                ]
+            }
+        }
+    }
+}

--- a/VocaVocca/Model/NetworkManager.swift
+++ b/VocaVocca/Model/NetworkManager.swift
@@ -15,7 +15,6 @@ class NetworkManager {
 
     func fetch<T: Decodable>(customURLComponents: CustomURLComponents) -> Single<T> {
         return Single.create { [weak self] single in
-
             guard let self = self,
                   let url = self.createURL(customURLComponents) else {
                 single(.failure(NetworkError.invalidURL)) // URL 에러 전달
@@ -55,7 +54,6 @@ class NetworkManager {
 
     // URL 생성 메서드
     private func createURL(_ customURLComponents: CustomURLComponents) -> URL? {
-
         var urlComponents = URLComponents()
         var queryItems = [URLQueryItem]()
 

--- a/VocaVocca/Model/TranslationsResponse.swift
+++ b/VocaVocca/Model/TranslationsResponse.swift
@@ -1,0 +1,22 @@
+//
+//  TranslationsResponse.swift
+//  VocaVocca
+//
+//  Created by mun on 1/9/25.
+//
+
+struct TranslationsResponse: Decodable {
+    let translations: [Translations]
+}
+
+extension TranslationsResponse {
+    struct Translations: Decodable {
+        let language: String
+        let text: String
+
+        enum CodingKeys: String, CodingKey {
+            case text
+            case language = "detected_source_language"
+        }
+    }
+}

--- a/VocaVocca/Resource/Info.plist
+++ b/VocaVocca/Resource/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APIKey</key>
+	<string>$(APIKey)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
### 📝 작업 내용
- DeepL API를 사용하여 단어의 뜻을 가져오는 `NetworkManager`를 구현했습니다.


### 🚀 주요 변경 사항
- Language 구현
  - 번역할 단어의 언어를 `Language` 열거형으로 정의
  - `rawValue`를 통해 `case` 설정 가능
  - `Language.title`을 사용하여 `urlComponents`의 `queryItems` 생성

- TranslationsResponse 구현
  - DeepL API 리퀘스트를 통해 오는 `response` 구조 정의
 
- NetworkManager 구현
  - 싱글톤으로 생성
  - 네트워크 에러에 대한 `NetworkError` 열거형 정의
  - `fetch` 메서드의 파라미터로 `CustomURLComponents` 받음 (아래와 같이 사용)
```
let customURLComponents = NetworkManager.CustomURLComponents.translation(text: "test", lang: Language.english)

NetworkManager.shared.fetch(customURLComponents: customURLComponents)
```

### 📷 스크린샷
<img width="349" alt="스크린샷 2025-01-09 오후 12 01 30" src="https://github.com/user-attachments/assets/2b5626cc-cb51-4bfb-8891-3df63e9d3935" />


### 💡 주의사항
- `tesst` 등 올바르지 않은 단어를 요청하면, 입력값 그대로 `return` → `NetworkManager`를 사용할 때 분기 처리 필요 ex) `input`과 `response`가 같은 경우 뜻 추천 X