### PR TITLE
[#50] VocaBookModalViewModel 구현

### DIFF
--- a/VocaVocca.xcodeproj/project.pbxproj
+++ b/VocaVocca.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F2116B652D33F0BE00B786B8 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = F2116B642D33F0BE00B786B8 /* RxCocoa */; };
 		F262F0342D2FF35400B3DFDB /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = F262F0332D2FF35400B3DFDB /* Config.xcconfig */; };
 		F2ED388D2D2E111F005B7BC0 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = F2ED388C2D2E111F005B7BC0 /* .gitignore */; };
 		F2ED38972D2E13A8005B7BC0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F2ED38962D2E13A8005B7BC0 /* SnapKit */; };
@@ -49,6 +50,7 @@
 			files = (
 				F2ED389A2D2E16AF005B7BC0 /* RxSwift in Frameworks */,
 				F2ED389D2D2E16E7005B7BC0 /* CoreData.framework in Frameworks */,
+				F2116B652D33F0BE00B786B8 /* RxCocoa in Frameworks */,
 				F2ED38972D2E13A8005B7BC0 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -97,6 +99,7 @@
 			packageProductDependencies = (
 				F2ED38962D2E13A8005B7BC0 /* SnapKit */,
 				F2ED38992D2E16AF005B7BC0 /* RxSwift */,
+				F2116B642D33F0BE00B786B8 /* RxCocoa */,
 			);
 			productName = VocaVocca;
 			productReference = BAB189962D2E7D4300E4DF7C /* VocaVocca.app */;
@@ -380,6 +383,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		F2116B642D33F0BE00B786B8 /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F2ED38982D2E16AE005B7BC0 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
 		F2ED38962D2E13A8005B7BC0 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F2ED38952D2E13A8005B7BC0 /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/VocaVocca/View/CustomView/CustomModalView.swift
+++ b/VocaVocca/View/CustomView/CustomModalView.swift
@@ -7,8 +7,15 @@
 
 import UIKit
 import SnapKit
+import RxSwift
+import RxCocoa
 
 class CustomModalView: UIView {
+    
+    // MARK: - Properties
+    
+    private let disposeBag = DisposeBag()
+    var vocaBookViewModel: VocaBookModalViewModel?
     
     // MARK: - UI Components
     

--- a/VocaVocca/View/CustomView/CustomModalView.swift
+++ b/VocaVocca/View/CustomView/CustomModalView.swift
@@ -12,7 +12,7 @@ class CustomModalView: UIView {
     
     // MARK: - UI Components
     
-    private let titleLabel: UILabel = {
+    let titleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.boldSystemFont(ofSize: 20)
         label.textAlignment = .center
@@ -20,7 +20,7 @@ class CustomModalView: UIView {
         return label
     }()
     
-    private lazy var closeButton: UIButton = {
+    lazy var closeButton: UIButton = {
         let button = UIButton()
         button.setTitle("✕", for: .normal)
         button.setTitleColor(.black, for: .normal)
@@ -36,7 +36,7 @@ class CustomModalView: UIView {
         return stackView
     }()
     
-    private let confirmButton: CustomButton
+    let confirmButton: CustomButton
     
     // MARK: - Initialization
     

--- a/VocaVocca/View/CustomView/CustomTextFieldView.swift
+++ b/VocaVocca/View/CustomView/CustomTextFieldView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import RxSwift
 
 class CustomTextFieldView: UIView {
     
@@ -19,7 +20,7 @@ class CustomTextFieldView: UIView {
         return label
     }()
     
-    private let textField: UITextField = {
+    let textField: UITextField = {
         let field = UITextField()
         field.borderStyle = .none
         field.font = UIFont.systemFont(ofSize: 14)

--- a/VocaVocca/View/Voca/VocaBookModalViewController.swift
+++ b/VocaVocca/View/Voca/VocaBookModalViewController.swift
@@ -64,7 +64,6 @@ class VocaBookModalViewController: UIViewController {
         super.viewDidLoad()
         setupView()
         setupLanguageButtons()
-        configureUI()
     }
     
     // MARK: - Setup
@@ -90,10 +89,6 @@ class VocaBookModalViewController: UIViewController {
         }
     }
     
-    private func configureUI() {
-        modalView.update(title: "단어장 만들기", buttonTitle: "추가하기")
-    }
-    
     private func createLanguageButton(for language: Language) -> UIButton {
         let button = UIButton(type: .system)
         button.setTitle(language.koreanTitle, for: .normal)
@@ -115,6 +110,7 @@ class VocaBookModalViewController: UIViewController {
     }
     
     // MARK: - bind
+    
     private func bindViewModel() {
         viewModel.title
             .bind(to: modalView.titleLabel.rx.text)

--- a/VocaVocca/View/Voca/VocaBookModalViewController.swift
+++ b/VocaVocca/View/Voca/VocaBookModalViewController.swift
@@ -129,8 +129,13 @@ class VocaBookModalViewController: UIViewController {
             .disposed(by: disposeBag)
     }
     
-    // TODO: - 언어 선택 UI 변경 구현
-    
     @objc private func languageButtonTapped(_ sender: UIButton) {
+        guard let language = Language(rawValue: sender.tag) else { return }
+        viewModel.selectedLanguage(language)
+        
+        for button in languageStackView.arrangedSubviews.compactMap({ $0 as? UIButton }) {
+            button.backgroundColor = .lightGray
+        }
+        sender.backgroundColor = .customDarkBrown
     }
 }

--- a/VocaVocca/View/Voca/VocaBookModalViewController.swift
+++ b/VocaVocca/View/Voca/VocaBookModalViewController.swift
@@ -127,6 +127,12 @@ class VocaBookModalViewController: UIViewController {
         viewModel.isSaveEnabled
             .bind(to: modalView.confirmButton.rx.isEnabled)
             .disposed(by: disposeBag)
+        
+        modalView.confirmButton.rx.tap
+            .bind { [weak self] in
+                self?.viewModel.handleSaveOrEdit()
+            }
+            .disposed(by: disposeBag)
     }
     
     @objc private func languageButtonTapped(_ sender: UIButton) {

--- a/VocaVocca/View/Voca/VocaBookModalViewController.swift
+++ b/VocaVocca/View/Voca/VocaBookModalViewController.swift
@@ -7,14 +7,18 @@
 
 import UIKit
 import SnapKit
+import RxSwift
 
 class VocaBookModalViewController: UIViewController {
-
+    
     // MARK: - Properties
-
+    
+    private let viewModel: VocaBookModalViewModel
+    private let disposeBag = DisposeBag()
+    
     private let modalView = CustomModalView(title: "", buttonTitle: "")
     private let textFieldView = CustomTextFieldView(title: "단어장 이름", placeholder: "입력해주세요.")
-
+    
     private let languageContainerStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -23,7 +27,7 @@ class VocaBookModalViewController: UIViewController {
         stackView.distribution = .fill
         return stackView
     }()
-
+    
     private let languageTitleLabel: UILabel = {
         let label = UILabel()
         label.text = "언어"
@@ -31,7 +35,7 @@ class VocaBookModalViewController: UIViewController {
         label.textColor = .brown
         return label
     }()
-
+    
     private let languageStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
@@ -40,55 +44,56 @@ class VocaBookModalViewController: UIViewController {
         stackView.distribution = .fillEqually
         return stackView
     }()
-
+    
     private let availableLanguages: [Language] = [.english, .chinese, .japanese, .german, .spanish]
-
+    
     // MARK: - Initialization
-
-    init() {
+    
+    init(viewModel: VocaBookModalViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     // MARK: - Lifecycle
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupView()
         setupLanguageButtons()
         configureUI()
     }
-
+    
     // MARK: - Setup
-
+    
     private func setupView() {
         view.backgroundColor = UIColor(white: 0, alpha: 0.5)
         view.addSubview(modalView)
-
+        
         modalView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalToSuperview().multipliedBy(0.85)
             $0.bottom.equalToSuperview()
         }
-
+        
         languageContainerStackView.addArrangedSubviews(languageTitleLabel, languageStackView)
         modalView.contentStackView.addArrangedSubviews(textFieldView, languageContainerStackView)
     }
-
+    
     private func setupLanguageButtons() {
         for language in availableLanguages {
             let button = createLanguageButton(for: language)
             languageStackView.addArrangedSubview(button)
         }
     }
-
+    
     private func configureUI() {
         modalView.update(title: "단어장 만들기", buttonTitle: "추가하기")
     }
-
+    
     private func createLanguageButton(for language: Language) -> UIButton {
         let button = UIButton(type: .system)
         button.setTitle(language.koreanTitle, for: .normal)
@@ -97,16 +102,35 @@ class VocaBookModalViewController: UIViewController {
         button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
         button.tag = language.rawValue
         button.translatesAutoresizingMaskIntoConstraints = false
-
+        
         button.snp.makeConstraints {
             $0.height.equalTo(40)
         }
-
+        
         button.layer.cornerRadius = 20
         button.layer.masksToBounds = true
-
+        
         button.addTarget(self, action: #selector(languageButtonTapped(_:)), for: .touchUpInside)
         return button
+    }
+    
+    // MARK: - bind
+    private func bindViewModel() {
+        viewModel.title
+            .bind(to: modalView.titleLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        viewModel.buttonTitle
+            .bind(to: modalView.confirmButton.rx.title(for: .normal))
+            .disposed(by: disposeBag)
+        
+        textFieldView.textField.rx.text.orEmpty
+            .bind(to: viewModel.vocaBookTitle)
+            .disposed(by: disposeBag)
+        
+        viewModel.isSaveEnabled
+            .bind(to: modalView.confirmButton.rx.isEnabled)
+            .disposed(by: disposeBag)
     }
     
     // TODO: - 언어 선택 UI 변경 구현

--- a/VocaVocca/ViewModel/Voca/VocaBookModalViewModel.swift
+++ b/VocaVocca/ViewModel/Voca/VocaBookModalViewModel.swift
@@ -14,6 +14,49 @@ enum Mode {
     case edit
 }
 
+struct VocaBook {
+    let title: String
+    let language: Language
+}
+
 class VocaBookModalViewModel {
     
+    // MARK: - Input
+    
+    let vocaBookTitle = BehaviorRelay<String>(value: "")
+    let selectedLanguage = BehaviorRelay<Language?>(value: nil)
+    
+    // MARK: - Output
+    
+    let isSaveEnabled: Observable<Bool>
+    let title: Observable<String>
+    let buttonTitle: Observable<String>
+    
+    // mode
+    private let mode: Mode
+    
+    // init
+    init(mode: Mode, initVocaBook: VocaBook? = nil) {
+        self.mode = mode
+        
+        // 수정 모드에서 단어장 이름 초기화
+        if let initVocaBook = initVocaBook, mode == .edit {
+            vocaBookTitle.accept(initVocaBook.title)
+            selectedLanguage.accept(initVocaBook.language)
+        }
+        
+        // 저장 버튼 활성화 여부 결정?
+        isSaveEnabled = Observable
+            .combineLatest(vocaBookTitle.asObservable(), selectedLanguage.asObservable())
+            .map { $0.isEmpty && $1 != nil}
+        
+        // 버튼, 텍스트
+        title = Observable.just(mode == .create ? "단어장 만들기": "단어장 수정하기")
+        buttonTitle = Observable.just(mode == .create ? "추가하기": "수정하기")
+    }
+    
+    // save edit
+    func handleSaveOrEdit() {
+        
+    }
 }

--- a/VocaVocca/ViewModel/Voca/VocaBookModalViewModel.swift
+++ b/VocaVocca/ViewModel/Voca/VocaBookModalViewModel.swift
@@ -55,6 +55,11 @@ class VocaBookModalViewModel {
         buttonTitle = Observable.just(mode == .create ? "추가하기": "수정하기")
     }
     
+    // selected language
+    func selectedLanguage(_ language: Language) {
+        selectedLanguage.accept(language)
+    }
+    
     // save edit
     func handleSaveOrEdit() {
         

--- a/VocaVocca/ViewModel/Voca/VocaBookModalViewModel.swift
+++ b/VocaVocca/ViewModel/Voca/VocaBookModalViewModel.swift
@@ -62,6 +62,18 @@ class VocaBookModalViewModel {
     
     // save edit
     func handleSaveOrEdit() {
+        guard let language = selectedLanguage.value, !vocaBookTitle.value.isEmpty else { return }
         
+        let vocaBook = VocaBook(title: vocaBookTitle.value, language: language)
+        
+        if mode == .create {
+            // TODO: - Core Data 단어장 추가
+            
+            print("단어장을 추가: \(vocaBook)")
+        } else {
+            // TODO: - Core Data 단어장 추가
+            
+            print("단어장을 수정: \(vocaBook)")
+        }
     }
 }

--- a/VocaVocca/ViewModel/Voca/VocaBookModalViewModel.swift
+++ b/VocaVocca/ViewModel/Voca/VocaBookModalViewModel.swift
@@ -6,3 +6,14 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
+
+enum Mode {
+    case create
+    case edit
+}
+
+class VocaBookModalViewModel {
+    
+}


### PR DESCRIPTION
### 📝 작업 내용
- `VocaBookModalViewModel` 구현
- Core Data와 연동하여 단어장 생성 및 수정 기능 추가
- `RxSwift`를 활용해 뷰모델과 뷰 간 반응형 데이터 바인딩 구현

### 🚀 주요 변경 사항
- `handleSaveOrEdit` 메서드 작성
  - **생성 모드 (`.create`)**: `CoreDataManager`의 `createVocaBookData`를 호출해 단어장 생성
  - **수정 모드 (`.edit`)**: 
    - `fetchVocaBookData`로 해당 단어장 조회
    - `updateVocaBookData` 호출로 단어장 이름 수정
- `RxSwift`의 `BehaviorRelay`와 `Observable`을 이용한 데이터 상태 관리:
  - `isSaveEnabled`로 저장 버튼 활성화 여부 제어
  - `title`, `buttonTitle`로 UI 텍스트 동적 변경

### 💡 추가 계획
- UI 연동 작업 및 상태 관리 최적화