### PR TITLE
[#53] 단어 전환 기능 구현

### DIFF
--- a/VocaVocca/View/Learning/FlashcardView.swift
+++ b/VocaVocca/View/Learning/FlashcardView.swift
@@ -21,9 +21,32 @@ class FlashcardView: UIView {
     }()
 
     // 진행된 숫자 표시 라벨
-    private let numberLabel: UILabel = {
+    private let countView = {
+        let view = UIView()
+        return view
+    }()
+    
+    let countLabel: UILabel = {
         let label = UILabel()
-        label.text = "1 / 10"
+        label.text = "1"
+        label.textColor = .customBlack
+        label.textAlignment = .center
+        label.font = .boldSystemFont(ofSize: 20)
+        return label
+    }()
+    
+    let connectLabel: UILabel = {
+        let label = UILabel()
+        label.text = "/"
+        label.textColor = .customBlack
+        label.textAlignment = .center
+        label.font = .boldSystemFont(ofSize: 20)
+        return label
+    }()
+    
+    let totalCountLabel: UILabel = {
+        let label = UILabel()
+        label.text = "10"
         label.textColor = .customBlack
         label.textAlignment = .center
         label.font = .boldSystemFont(ofSize: 20)
@@ -39,7 +62,7 @@ class FlashcardView: UIView {
     }()
 
     // 단어 라벨
-    private let wordLabel: UILabel = {
+    let wordLabel: UILabel = {
         let label = UILabel()
         label.text = "test"
         label.textColor = .customBlack
@@ -96,7 +119,8 @@ class FlashcardView: UIView {
     private func setupUI() {
         backgroundColor = .systemGray5
 
-        addSubviews(closeButton, numberLabel, flashcardView, buttonStackView)
+        addSubviews(closeButton, countView, flashcardView, buttonStackView)
+        countView.addSubviews(countLabel, connectLabel, totalCountLabel)
         flashcardView.addSubview(wordLabel)
         buttonStackView.addArrangedSubviews(notYetButton, gotItButton)
 
@@ -106,13 +130,29 @@ class FlashcardView: UIView {
             $0.height.equalTo(20)
         }
 
-        numberLabel.snp.makeConstraints {
+        countView.snp.makeConstraints {
             $0.top.equalTo(closeButton.snp.top)
             $0.centerX.equalToSuperview()
+            $0.width.equalTo(200)
+            $0.height.equalTo(50)
         }
-
+        
+        countLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalTo(connectLabel.snp.leading).offset(-10)
+        }
+        
+        connectLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        totalCountLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(connectLabel.snp.trailing).offset(10)
+        }
+        
         flashcardView.snp.makeConstraints {
-            $0.top.equalTo(numberLabel.snp.bottom).offset(30)
+            $0.top.equalTo(countView.snp.bottom).offset(30)
             $0.bottom.equalTo(buttonStackView.snp.top).offset(-30)
             $0.horizontalEdges.equalToSuperview().inset(30)
         }

--- a/VocaVocca/View/Learning/LearningViewController.swift
+++ b/VocaVocca/View/Learning/LearningViewController.swift
@@ -60,9 +60,10 @@ final class LearningViewController: UIViewController {
                 cell.vocaCountLabel.text = "\(item.words?.count ?? 0) 개"
             }.disposed(by: disposeBag)
         
-        // 선택된 셀 바인딩
-        learningView.collectionView.rx.modelSelected(VocaBookData.self)
-            .bind(to: viewModel.selectedVocaBook)
+        learningView.collectionView.rx.itemSelected
+            .subscribe(onNext: { [weak self] indexPath in
+                self?.viewModel.changeIndex(indexPath.item)
+            })
             .disposed(by: disposeBag)
         
         // 버튼 액션 바인딩
@@ -70,20 +71,15 @@ final class LearningViewController: UIViewController {
             .subscribe(onNext: { [weak self] in
                 self?.navigateToFlashCard()
             })
-            .disposed(by: disposeBag)
+            .disposed(by: disposeBag)///ㅇ
     }
     
     private func navigateToFlashCard() {
-          guard let selectedBook = viewModel.selectedVocaBook.value else {
-              // 선택된 단어장이 없는 경우 알럿
-              let alert = UIAlertController(title: "단어장 선택", message: "시작할 단어장을 선택해주세요.", preferredStyle: .alert)
-              alert.addAction(UIAlertAction(title: "확인", style: .default))
-              present(alert, animated: true)
-              return
-          }
-          
-          let flashCardVM = FlashCardViewModel(data: selectedBook)
-          let flashcardVC = FlashcardViewController(viewModel: flashCardVM)
-          navigationController?.pushViewController(flashcardVC, animated: true)
+        viewModel.addTestVocaBooks()
+        let data = viewModel.getData()
+        
+        let flashCardVM = FlashcardViewModel(data: data)
+        let flashcardVC = FlashcardViewController(viewModel: flashCardVM)
+        navigationController?.pushViewController(flashcardVC, animated: true)
       }
 }

--- a/VocaVocca/ViewModel/Learning/FlashcardViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/FlashcardViewModel.swift
@@ -9,16 +9,48 @@ import Foundation
 import RxSwift
 
 class FlashcardViewModel {
-
-    var manager = UserDefaultsManager()
-    var subject = PublishSubject<Bool>()
-
-    func isCoachMarkDisabled() {
-        if manager.isCoachMarkDisabled() {
-            subject.onNext(true)
+    
+    let isCoachMarkDisabled = BehaviorSubject(value: false) // 사용자가 코치마크를 비활성화했는지 여부
+    let currentVoca: BehaviorSubject<VocaData?> // 현재 단어
+    let currentIndex = BehaviorSubject(value: 0) // 현재 카드의 인덱스
+    let totalVocaCount: BehaviorSubject<Int> // 전체 단어 수
+    let isLastVoca: BehaviorSubject<Bool> // 마지막 단어인지 여부
+    
+    private let allVocaData: [VocaData] // 전체 단어 데이터
+    private var currentIndexValue = 0 // 인덱스 변경을 위한 변수
+    private var correctWords = [VocaData]() // 맞춘 단어 목록
+    private var incorrectWords = [VocaData]() // 틀린 단어 목록
+    
+    init(data: VocaBookData) {
+        allVocaData = data.words?.allObjects as? [VocaData] ?? []
+        totalVocaCount = BehaviorSubject(value: allVocaData.count)
+        currentVoca = BehaviorSubject(value: allVocaData.first)
+        isLastVoca = BehaviorSubject(value: currentIndexValue == allVocaData.count ? true : false)
+        checkIfCoachMarkShouldBeDisabled()
+    }
+    
+    private func checkIfCoachMarkShouldBeDisabled() {
+        if UserDefaultsManager().isCoachMarkDisabled() {
+            isCoachMarkDisabled.onNext(true)
         } else {
-            subject.onNext(false)
+            isCoachMarkDisabled.onNext(false)
         }
     }
-
+    
+    func markWordAsCorrect() {
+        moveToNextVoca()
+        correctWords.append(allVocaData[currentIndexValue - 1])
+    }
+    
+    func markWordsAsIncorrect() {
+        moveToNextVoca()
+        incorrectWords.append(allVocaData[currentIndexValue - 1])
+    }
+    
+    private func moveToNextVoca() {
+        currentIndexValue += 1
+        currentIndex.onNext(currentIndexValue)
+        currentVoca.onNext(allVocaData[currentIndexValue])
+        isLastVoca.onNext(currentIndexValue + 1 == allVocaData.count)
+    }
 }

--- a/VocaVocca/ViewModel/Learning/LearningViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/LearningViewModel.swift
@@ -16,6 +16,9 @@ class LearningViewModel {
     let vocaBookSubject = BehaviorSubject(value: [VocaBookData]())
     let selectedVocaBook = BehaviorSubject<VocaBookData?>(value: nil)
     
+    var data = [VocaBookData]()
+    var index = 0
+    
     init () {
         fetchVocaBookFromCoreData()
     }
@@ -24,6 +27,8 @@ class LearningViewModel {
         CoreDataManager.shared.fetchVocaBookData()
             .subscribe(onNext: { [weak self] vocaBookData in
                 self?.vocaBookSubject.onNext(vocaBookData)
+                self?.data = vocaBookData
+                print(vocaBookData)
             }, onError: { error in
                 self.vocaBookSubject.onError(error)
             }).disposed(by: disposeBag)
@@ -40,10 +45,22 @@ class LearningViewModel {
     }
     
     private func createTestVocaBookData() -> Completable {
+        
         return Completable.zip(
-            CoreDataManager.shared.createVocaBookData(title: "토익"),
-            CoreDataManager.shared.createVocaBookData(title: "중국어 기초"),
-            CoreDataManager.shared.createVocaBookData(title: "일본어 공부")
+            CoreDataManager.shared.createVocaBookData(title: "단어장"),
+            CoreDataManager.shared.createVocaData(word: "hssss", meaning: "텍스트", language: Language.english.koreanTitle, book: data.last!),
+            CoreDataManager.shared.createVocaData(word: "hssss", meaning: "테스트", language: Language.english.koreanTitle, book: data.last!),
+            CoreDataManager.shared.createVocaData(word: "tdfas", meaning: "테스트2", language: Language.english.koreanTitle, book: data.last!),
+            CoreDataManager.shared.createVocaData(word: "asfda", meaning: "테스트3", language: Language.english.koreanTitle, book: data.last!),
+            CoreDataManager.shared.createVocaData(word: "asdf", meaning: "테스트4", language: Language.english.koreanTitle, book: data.last!)
         )
+    }
+    
+    func changeIndex(_ index: Int) {
+        self.index = index
+    }
+    
+    func getData() -> VocaBookData {
+        return data.first!
     }
 }


### PR DESCRIPTION
### 📝 작업 내용
하단 버튼을 누르면 다음 단어로 전환되는 기능을 구현했습니다. 

### 🚀 주요 변경 사항
- 하단 버튼 클릭 시 단어 전환 및 데이터 저장
  - gotItButton → `correctWords`에 데이터 추가
  - notYetButton → `incorrectWords`에 데이터 추가
- LearningViewController 수정
  - `FlashcardViewController`에 데이터 전달을 위한 임시 수정

### 📷 스크린샷
![Simulator Screen Recording - iPhone 16 Pro - 2025-01-13 at 19 25 22](https://github.com/user-attachments/assets/e00d2f36-b30a-4fd7-aa03-aa4f5e505741)


### 💡 추가 계획
  - 마지막 단어일 경우, 결과 화면과 이어지게 구현