### PR TITLE
[#61] 플래시카드 화면에 결과 화면 연결

### DIFF
--- a/VocaVocca.xcodeproj/project.pbxproj
+++ b/VocaVocca.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		F2116B652D33F0BE00B786B8 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = F2116B642D33F0BE00B786B8 /* RxCocoa */; };
-		F262F0342D2FF35400B3DFDB /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = F262F0332D2FF35400B3DFDB /* Config.xcconfig */; };
+		F262F0342D2FF35400B3DFDB /* (null) in Resources */ = {isa = PBXBuildFile; };
 		F2ED388D2D2E111F005B7BC0 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = F2ED388C2D2E111F005B7BC0 /* .gitignore */; };
 		F2ED38972D2E13A8005B7BC0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = F2ED38962D2E13A8005B7BC0 /* SnapKit */; };
 		F2ED389A2D2E16AF005B7BC0 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F2ED38992D2E16AF005B7BC0 /* RxSwift */; };
@@ -60,7 +60,6 @@
 		F2ED383B2D2E10D8005B7BC0 = {
 			isa = PBXGroup;
 			children = (
-				F262F0332D2FF35400B3DFDB /* Config.xcconfig */,
 				F2ED38462D2E10D8005B7BC0 /* VocaVocca */,
 				F2ED388C2D2E111F005B7BC0 /* .gitignore */,
 				F2ED389B2D2E16E7005B7BC0 /* Frameworks */,
@@ -147,7 +146,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F262F0342D2FF35400B3DFDB /* Config.xcconfig in Resources */,
+				F262F0342D2FF35400B3DFDB /* (null) in Resources */,
 				F2ED388D2D2E111F005B7BC0 /* .gitignore in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -167,7 +166,6 @@
 /* Begin XCBuildConfiguration section */
 		F2ED38582D2E10D8005B7BC0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F262F0332D2FF35400B3DFDB /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/VocaVocca/Model/LearningResult.swift
+++ b/VocaVocca/Model/LearningResult.swift
@@ -1,0 +1,11 @@
+//
+//  LearningResult.swift
+//  VocaVocca
+//
+//  Created by 서문가은 on 1/13/25.
+//
+
+struct LearningResult {
+    let correctCount: Int
+    let IncorrectCount: Int
+}

--- a/VocaVocca/View/Learning/FlashcardViewController.swift
+++ b/VocaVocca/View/Learning/FlashcardViewController.swift
@@ -52,7 +52,7 @@ class FlashcardViewController: UIViewController {
             .filter { $0 == false }
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }
-                self.connectModal()
+                self.connectCoachmarkModal()
             })
             .disposed(by: disposeBag)
         
@@ -74,7 +74,9 @@ class FlashcardViewController: UIViewController {
         flashcardViewModel.isLastVoca
             .filter { $0 }
             .bind { [weak self] _ in
-                print("마지막 단어") // 수정 필요
+                guard let self = self else { return }
+                self.connectResultModal()
+                self.flashcardViewModel.saveResults()
             }
             .disposed(by: disposeBag)
         
@@ -100,10 +102,16 @@ class FlashcardViewController: UIViewController {
             .disposed(by: disposeBag)
     }
     
-    private func connectModal() {
+    private func connectCoachmarkModal() {
         let coachmarkVC = CoachmarkViewController()
         coachmarkVC.modalPresentationStyle = .overFullScreen
         present(coachmarkVC, animated: false)
+    }
+    
+    private func connectResultModal() {
+        let learningResultVC = LearningResultViewController()
+        learningResultVC.modalPresentationStyle = .overFullScreen
+        present(learningResultVC, animated: true)
     }
     
     private func closeButtonTapped() {

--- a/VocaVocca/View/Learning/FlashcardViewController.swift
+++ b/VocaVocca/View/Learning/FlashcardViewController.swift
@@ -48,6 +48,7 @@ class FlashcardViewController: UIViewController {
     // MARK: - bind
     
     private func bind() {
+        // 코치마크 비활성화 여부 바인드
         flashcardViewModel.isCoachMarkDisabled
             .filter { $0 == false }
             .subscribe(onNext: { [weak self] _ in
@@ -56,37 +57,41 @@ class FlashcardViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        // 현재 단어 바인드
         flashcardViewModel.currentVoca
             .map { $0?.word }
             .bind(to: flashcardView.wordLabel.rx.text)
             .disposed(by: disposeBag)
         
+        // 현재 인덱스 바인드
         flashcardViewModel.currentIndex
             .map { "\($0 + 1)" }
             .bind(to: flashcardView.countLabel.rx.text)
             .disposed(by: disposeBag)
         
+        // 보카 단어 수 바인드
         flashcardViewModel.totalVocaCount
             .map { "\($0)" }
             .bind(to: flashcardView.totalCountLabel.rx.text)
             .disposed(by: disposeBag)
         
-        flashcardViewModel.isLastVoca
-            .filter { $0 }
-            .bind { [weak self] _ in
+        // 학습 결과 바인드
+        flashcardViewModel.learningResult
+            .bind { [weak self] result in
                 guard let self = self else { return }
-                self.connectResultModal()
-                self.flashcardViewModel.saveResults()
+                self.connectLearningResultModal(result)
             }
             .disposed(by: disposeBag)
         
+        // 닫기 버튼 클릭 바인드
         flashcardView.closeButton.rx.tap
             .bind { [weak self] _ in
                 guard let self = self else { return }
                 self.closeButtonTapped()
             }
             .disposed(by: disposeBag)
-                
+        
+        // 알아요 버튼 클릭 바인드
         flashcardView.gotItButton.rx.tap
             .bind { [weak self] _ in
                 guard let self = self else { return }
@@ -94,6 +99,7 @@ class FlashcardViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
+        // 잘몰라요 버튼 클릭 바인드
         flashcardView.notYetButton.rx.tap
             .bind { [weak self] _ in
                 guard let self = self else { return }
@@ -102,18 +108,23 @@ class FlashcardViewController: UIViewController {
             .disposed(by: disposeBag)
     }
     
+    // 코치마크 모달 연결
     private func connectCoachmarkModal() {
         let coachmarkVC = CoachmarkViewController()
         coachmarkVC.modalPresentationStyle = .overFullScreen
         present(coachmarkVC, animated: false)
     }
     
-    private func connectResultModal() {
-        let learningResultVC = LearningResultViewController()
+    // 결과 모달 연결
+    private func connectLearningResultModal(_ result: LearningResult) {
+        print(result)
+        let learningResultVM = LearningResultViewModel(learningResult: result)
+        let learningResultVC = LearningResultViewController(viewModel: learningResultVM)
         learningResultVC.modalPresentationStyle = .overFullScreen
         present(learningResultVC, animated: true)
     }
     
+    // 닫기 버튼 클릭
     private func closeButtonTapped() {
         navigationController?.popViewController(animated: true)
     }

--- a/VocaVocca/View/Learning/LearningResultViewController.swift
+++ b/VocaVocca/View/Learning/LearningResultViewController.swift
@@ -11,6 +11,16 @@ import SnapKit
 final class LearningResultViewController: UIViewController {
     
     private let learningResultView = LearningResultView()
+    private let viewModel: LearningResultViewModel
+    
+    init(viewModel: LearningResultViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func loadView() {
         self.view = learningResultView

--- a/VocaVocca/ViewModel/Learning/FlashcardViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/FlashcardViewModel.swift
@@ -8,12 +8,6 @@
 import Foundation
 import RxSwift
 
-
-struct LearningResult {
-    let correctCount: Int
-    let IncorrectCount: Int
-}
-
 class FlashcardViewModel {
     
     let isCoachMarkDisabled = BehaviorSubject(value: false) // 사용자가 코치마크를 비활성화했는지 여부

--- a/VocaVocca/ViewModel/Learning/FlashcardViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/FlashcardViewModel.swift
@@ -53,4 +53,19 @@ class FlashcardViewModel {
         currentVoca.onNext(allVocaData[currentIndexValue])
         isLastVoca.onNext(currentIndexValue + 1 == allVocaData.count)
     }
+    
+    // 정답 결과 저장
+    func saveResults() {
+        print("correctWords")
+        print(correctWords)
+        print("incorrectWords")
+        print(incorrectWords)
+        correctWords.forEach {
+            CoreDataManager.shared.createRecordData(voca: $0, isCorrected: true, date: Date())
+        }
+        
+        incorrectWords.forEach {
+            CoreDataManager.shared.createRecordData(voca: $0, isCorrected: false, date: Date())
+        }
+    }
 }

--- a/VocaVocca/ViewModel/Learning/FlashcardViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/FlashcardViewModel.swift
@@ -8,13 +8,19 @@
 import Foundation
 import RxSwift
 
+
+struct LearningResult {
+    let correctCount: Int
+    let IncorrectCount: Int
+}
+
 class FlashcardViewModel {
     
     let isCoachMarkDisabled = BehaviorSubject(value: false) // 사용자가 코치마크를 비활성화했는지 여부
     let currentVoca: BehaviorSubject<VocaData?> // 현재 단어
     let currentIndex = BehaviorSubject(value: 0) // 현재 카드의 인덱스
     let totalVocaCount: BehaviorSubject<Int> // 전체 단어 수
-    let isLastVoca: BehaviorSubject<Bool> // 마지막 단어인지 여부
+    let learningResult = PublishSubject<LearningResult>()
     
     private let allVocaData: [VocaData] // 전체 단어 데이터
     private var currentIndexValue = 0 // 인덱스 변경을 위한 변수
@@ -25,10 +31,10 @@ class FlashcardViewModel {
         allVocaData = data.words?.allObjects as? [VocaData] ?? []
         totalVocaCount = BehaviorSubject(value: allVocaData.count)
         currentVoca = BehaviorSubject(value: allVocaData.first)
-        isLastVoca = BehaviorSubject(value: currentIndexValue == allVocaData.count ? true : false)
         checkIfCoachMarkShouldBeDisabled()
     }
     
+    // 코치마크가 비활성화되었는지 확인
     private func checkIfCoachMarkShouldBeDisabled() {
         if UserDefaultsManager().isCoachMarkDisabled() {
             isCoachMarkDisabled.onNext(true)
@@ -37,29 +43,34 @@ class FlashcardViewModel {
         }
     }
     
+    // 맞은 단어 표시
     func markWordAsCorrect() {
+        correctWords.append(allVocaData[currentIndexValue])
         moveToNextVoca()
-        correctWords.append(allVocaData[currentIndexValue - 1])
     }
     
+    // 틀린 단어 표시
     func markWordsAsIncorrect() {
+        incorrectWords.append(allVocaData[currentIndexValue])
         moveToNextVoca()
-        incorrectWords.append(allVocaData[currentIndexValue - 1])
     }
     
+    // 다음 단어로 이동
     private func moveToNextVoca() {
-        currentIndexValue += 1
-        currentIndex.onNext(currentIndexValue)
-        currentVoca.onNext(allVocaData[currentIndexValue])
-        isLastVoca.onNext(currentIndexValue + 1 == allVocaData.count)
+        // 마지막 단어인지 확인
+        if currentIndexValue + 1 == allVocaData.count {
+            saveResults() // 결과 저장
+            let reslut = LearningResult(correctCount: correctWords.count, IncorrectCount: incorrectWords.count)
+            learningResult.onNext(reslut)
+        } else {
+            currentIndexValue += 1
+            currentIndex.onNext(currentIndexValue)
+            currentVoca.onNext(allVocaData[currentIndexValue])
+        }
     }
     
-    // 정답 결과 저장
+    // 학습 결과 저장
     func saveResults() {
-        print("correctWords")
-        print(correctWords)
-        print("incorrectWords")
-        print(incorrectWords)
         correctWords.forEach {
             CoreDataManager.shared.createRecordData(voca: $0, isCorrected: true, date: Date())
         }

--- a/VocaVocca/ViewModel/Learning/LearningResultViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/LearningResultViewModel.swift
@@ -6,3 +6,13 @@
 //
 
 import Foundation
+
+class LearningResultViewModel {
+    let correctCount: Int
+    let inCorrectCount: Int
+    
+    init(learningResult: LearningResult) {
+        self.correctCount = learningResult.correctCount
+        self.inCorrectCount = learningResult.IncorrectCount
+    }
+}


### PR DESCRIPTION
### 📝 작업 내용
마지막 단어에서 하단 버튼을 클릭하면 데이터를 저장하고 결과 화면을 모달로 전환하는 기능을 구현했습니다. 

### 🚀 주요 변경 사항
- `learningResult` 서브젝트
  - 마지막 단어인 경우, 코어데이터에 값을 저장하고, `learningResult` 이벤트 방출
  - `learningResult` 이벤트가 방출되면, `flashcardVC`에서는 결과 화면 모달로 전환
- `LearningResult` 구조체 정의
  - 맞은 횟수와 틀린 횟수 저장

### 📷 스크린샷
![Simulator Screen Recording - iPhone 16 Pro - 2025-01-13 at 20 54 02](https://github.com/user-attachments/assets/c8fffc46-dc1d-4707-873d-24c3863ba907)

### 💡 추가 계획
- 결과 화면 VM 구현