### PR TITLE
[#72] 학습결과 정답률에 따른 이미지 설정

### DIFF
--- a/VocaVocca/View/Learning/LearningResultView.swift
+++ b/VocaVocca/View/Learning/LearningResultView.swift
@@ -74,7 +74,6 @@ final class LearningResultView: UIView {
         return label
     }()
     
-    ///TODO - (현재 비어있음) 커피콩 이미지, 로직 추가구현 필요
     private lazy var coffeeStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -82,6 +81,9 @@ final class LearningResultView: UIView {
         stackView.distribution = .fillEqually
         return stackView
     }()
+    
+    // 커피콩 이미지 담을 배열
+    private var coffeeBeans: [UIImageView] = []
     
     private let resultDiscriptionLabel: UILabel = {
         let label = UILabel()
@@ -101,6 +103,7 @@ final class LearningResultView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        setupCoffeeBeans()
     }
     
     required init?(coder: NSCoder) {
@@ -164,6 +167,35 @@ final class LearningResultView: UIView {
             $0.horizontalEdges.equalToSuperview().inset(20)
             $0.height.equalTo(50)
             $0.centerX.equalToSuperview()
+        }
+    }
+    
+    private func setupCoffeeBeans() {
+        
+        // 가로 두줄
+        for _ in 0..<2 {
+            let horizontalStackView = UIStackView()
+            horizontalStackView.axis = .horizontal
+            horizontalStackView.spacing = 8
+            horizontalStackView.distribution = .fillEqually
+            
+            ///TODO - 
+            // 한줄에 5개 이미지
+            for _ in 0..<5 {
+                let imageView = UIImageView(image: UIImage(systemName: "circle.fill"))
+                imageView.tintColor = .customDarkerBrown
+                imageView.alpha = 0.2
+                coffeeBeans.append(imageView)
+                horizontalStackView.addArrangedSubview(imageView)
+            }
+            coffeeStackView.addArrangedSubview(horizontalStackView)
+        }
+    }
+    
+    // 커피콩 갯수 업데이트
+    func updateCoffeeBeans(correctCount: Int) {
+        for (index, imageView) in coffeeBeans.enumerated() {
+            imageView.alpha = index < correctCount ? 1.0 : 0.2
         }
     }
 }

--- a/VocaVocca/View/Learning/LearningResultViewController.swift
+++ b/VocaVocca/View/Learning/LearningResultViewController.swift
@@ -52,6 +52,13 @@ final class LearningResultViewController: UIViewController {
             .bind(to: learningResultView.correctRateLabel.rx.text)
             .disposed(by: disposeBag)
         
+        // 커피콩 개수 바인딩
+        viewModel.filledBeanCount
+            .subscribe(onNext: { [weak self] filledCount in
+                self?.learningResultView.updateCoffeeBeans(correctCount: filledCount)
+            })
+            .disposed(by: disposeBag)
+        
         // 닫기 서브젝트 바인딩
         viewModel.closeSubject
             .bind { [weak self] _ in

--- a/VocaVocca/View/Learning/LearningViewController.swift
+++ b/VocaVocca/View/Learning/LearningViewController.swift
@@ -77,11 +77,14 @@ final class LearningViewController: UIViewController {
             .disposed(by: disposeBag)
     }
     
+    // 단어장 단어 0개면 화면 안넘어가도록
     private func navigateToFlashCard() {
-        guard let selectedBook = self.viewModel.selectedVocaBook else { return }
-        
-        let flashCardVM = FlashcardViewModel(data: selectedBook)
-        let flashcardVC = FlashcardViewController(viewModel: flashCardVM)
-        self.navigationController?.pushViewController(flashcardVC, animated: true)
+        if viewModel.checkWordsCount() {
+            guard let selectedBook = self.viewModel.selectedVocaBook else { return }
+            
+            let flashCardVM = FlashcardViewModel(data: selectedBook)
+            let flashcardVC = FlashcardViewController(viewModel: flashCardVM)
+            self.navigationController?.pushViewController(flashcardVC, animated: true)
+        }
     }
 }

--- a/VocaVocca/ViewModel/Learning/LearningResultViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/LearningResultViewModel.swift
@@ -13,6 +13,7 @@ class LearningResultViewModel {
     let inCorrectCount: BehaviorSubject<Int>
     let correctRate: BehaviorSubject<Int>
     let closeSubject = PublishSubject<Bool>()
+    let filledBeanCount: Observable<Int> // 커피콩 개수
     
     init(learningResult: LearningResult) {
         let correctCount = learningResult.correctCount
@@ -22,6 +23,12 @@ class LearningResultViewModel {
         
         let result = Float(correctCount) / Float(correctCount + inCorrectCount) * 100
         correctRate = BehaviorSubject(value: Int(result))
+        
+        // 커피콩 개수 계산 (10%마다 1개)
+        self.filledBeanCount = correctRate
+            .map { result in
+                return min(result / 10, 10) // 10개를 넘지 않도록 제한
+            }
     }
     
     func closeAction() {

--- a/VocaVocca/ViewModel/Learning/LearningResultViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/LearningResultViewModel.swift
@@ -27,7 +27,7 @@ class LearningResultViewModel {
         // 커피콩 개수 계산 (10%마다 1개)
         self.filledBeanCount = correctRate
             .map { result in
-                return min(result / 10, 10) // 10개를 넘지 않도록 제한
+                return result / 10
             }
     }
     

--- a/VocaVocca/ViewModel/Learning/LearningViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/LearningViewModel.swift
@@ -22,6 +22,12 @@ class LearningViewModel {
         fetchVocaBookFromCoreData()
     }
     
+    // 단어장의 단어 개수를 확인해 이동 가능 여부를 반환
+    func checkWordsCount() -> Bool {
+        guard let selectedBook = selectedVocaBook else { return false }
+        return selectedBook.words?.count ?? 0 > 0
+    }
+    
     private func fetchVocaBookFromCoreData () {
         CoreDataManager.shared.fetchVocaBookData()
             .subscribe(onNext: { [weak self] vocaBookData in
@@ -43,12 +49,12 @@ class LearningViewModel {
             })
             .disposed(by: disposeBag)
     }
-
+    
     // 테스트 단어장 생성
     private func createTestVocaBookData() -> Completable {
         return CoreDataManager.shared.createVocaBookData(title: "테스트 단어장")
     }
-
+    
     // 테스트 단어 추가
     private func addTestVocaData() -> Completable {
         guard let firstBook = data.first else {


### PR DESCRIPTION
### 📝 작업 내용
  - 학습결과뷰에 나오는 이미지 설정
  - 단어장 단어 0개일때 학습 시작 x

### 🚀 주요 변경 사항
- 단어장 단어 0개일때 학습 시작 x
- 정답률에 따라 10퍼센트당 1개의 이미지에 색칠

### 📷 스크린샷
<img width="400" alt="" src="https://github.com/user-attachments/assets/467f88ab-6145-48ee-b17c-14e5cbf7a0ab" />

### 💡 추가 계획
  - 커피콩 이미지로 변경