### PR TITLE
[#73] 기록 데이터 중복 저장 문제 해결

### DIFF
--- a/VocaVocca/Model/CoreDataManager.swift
+++ b/VocaVocca/Model/CoreDataManager.swift
@@ -216,9 +216,10 @@ class CoreDataManager {
     }
     
     // RecordData를 업데이트하는 메서드.
-    func updateRecordData(record: RecordData, isCorrected: Bool) -> Completable {
+    func updateRecordData(record: RecordData, isCorrected: Bool, date: Date) -> Completable {
         return Completable.create { completable in
             record.iscorrected = isCorrected
+            record.date = date
             completable(.completed)
             return Disposables.create()
         }.concat(self.saveContext())


### PR DESCRIPTION
### 📝 작업 내용
기록 데이터가 중복 저장되는 문제를 해결했습니다. 

### 🚀 주요 변경 사항
- `VocaData`에 `RecordData`가 있으면 `RecordData` `update`, 없으면 `create`
- `CoreDataManager`의 `updateRecordData` 메서드에 `date` 파라미터 추가 