### PR TITLE
[#68] 메인화면 UI 수정 및 데이터 연결

### DIFF
--- a/VocaVocca/Model/UserDefaultsManager.swift
+++ b/VocaVocca/Model/UserDefaultsManager.swift
@@ -21,3 +21,18 @@ class UserDefaultsManager: NSObject {
         return UserDefaults.standard.bool(forKey: key)
     }
 }
+
+extension UserDefaultsManager {
+    
+    // 단어장 ID 저장
+    func setVocaBookId(id: String) {
+        UserDefaults.standard.set(UUID(uuidString: id),forKey: "chosenVocaBook")
+    }
+    
+    // 저장된 단어장 ID 조회
+    func getVocaBookID() -> String? {
+        guard let id = UserDefaults.standard.string(forKey: "chosenVocaBook") else { return "" }
+        return id
+    }
+    
+}

--- a/VocaVocca/View/Voca/VocaMainTableViewCell.swift
+++ b/VocaVocca/View/Voca/VocaMainTableViewCell.swift
@@ -12,7 +12,7 @@ class VocaMainTableViewCell: UITableViewCell {
     
     static let id = "VocaMainTableViewCell"
     
-    private let cardView = CustomCardView()
+    let cardView = CustomCardView()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -30,11 +30,6 @@ class VocaMainTableViewCell: UITableViewCell {
         cardView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
         }
-    }
-    
-    func configureCell() {
-        cardView.meanLabel.text = "하얀색"
-        cardView.wordLabel.text = "White"
     }
 }
 

--- a/VocaVocca/View/Voca/VocaMainTableViewCell.swift
+++ b/VocaVocca/View/Voca/VocaMainTableViewCell.swift
@@ -13,22 +13,47 @@ class VocaMainTableViewCell: UITableViewCell {
     static let id = "VocaMainTableViewCell"
     
     let cardView = CustomCardView()
+    let customTag = CustomTagView()
+    
+    let removeButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "trash"), for: .normal)
+        button.tintColor = .gray
+        return button
+    }()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         contentView.backgroundColor = .white
         setupUI()
-     }
+    }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     private func setupUI() {
-        addSubview(cardView)
+        customTag.subviews.first?.backgroundColor = .lightGray
+        customTag.setTagView(layerColor: .lightGray, label: "영어", textColor: .white)
+        
+        cardView.addSubviews(customTag, removeButton)
+        addSubviews(cardView)
         
         cardView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
+        }
+        
+        customTag.snp.makeConstraints {
+            $0.bottom.equalTo(cardView.snp.bottom).offset(120)
+            $0.leading.equalTo(cardView.snp.leading).inset(-150)
+            $0.width.equalTo(45)
+            $0.height.equalTo(20)
+        }
+        
+        removeButton.snp.makeConstraints {
+            $0.bottom.equalTo(cardView.snp.bottom).offset(120)
+            $0.trailing.equalTo(cardView.snp.trailing).offset(150)
+            $0.width.height.equalTo(20)
         }
     }
 }

--- a/VocaVocca/View/Voca/VocaMainViewController.swift
+++ b/VocaVocca/View/Voca/VocaMainViewController.swift
@@ -14,8 +14,7 @@ final class VocaMainViewController: UIViewController {
     private let vocaMainView = VocaMainView()
     private let vocaMainViewModel = VocaMainViewModel()
     private let vocaBookSelectViewController = VocaBookSelectViewController()
-    private var vocaBookData = VocaBookData()
-    
+        
     private let vocaModalViewController: VocaModalViewController = {
         let viewModel = VocaModalViewModel()
         let viewController = VocaModalViewController(viewModel: viewModel)
@@ -29,31 +28,51 @@ final class VocaMainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setup()
-//        fetchVocaBookData()
+        fetchVocaBookData()
         bindViewEvents()
+        bindTableView()
+        setUpNaviBar()
+    }
+    
+    // MARK: - 네비게이션 바
+    
+    private func setUpNaviBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .white
+        appearance.shadowColor = nil
+        
+        navigationController?.navigationBar.tintColor = .customBlack
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
     }
     
     private func setup() {
         view = vocaMainView
         vocaMainView.vocaTableView.register(VocaMainTableViewCell.self, forCellReuseIdentifier: "VocaMainTableViewCell")
-        vocaMainView.vocaTableView.dataSource = self
         vocaMainView.vocaTableView.rowHeight = 160
         vocaMainView.vocaTableView.separatorStyle = .none
     }
     
-//    private func fetchVocaBookData() {
-//        vocaMainViewModel.vocaBookSubject.subscribe(onNext: { vocaBookData in
-//
-//            self.vocaBookData = vocaBookData
-//            
+    // MARK: - 선택된 단어장 조회
+    
+    private func fetchVocaBookData() {
+        vocaMainViewModel.vocaBookSubject.subscribe(onNext: { vocaBookData in
+            
+            //TODO: 단어장 선택 시 값 받아오도록 할 예정
+//            self.vocaBookData = vocaBookData[0]
+//            let vocaBook = vocaBookData.last!
+//            print("vocaBookData :::::: \(vocaBook)")
 //            if let vocaBookTitle = vocaBookData.title {
 //                self.vocaMainView.vocaBookSelectButton.setTitle(vocaBookTitle, for: .normal)
 //            } else {
 //                self.vocaMainView.vocaBookSelectButton.setTitle("단어장을 생성해 주세요 >", for: .normal)
 //            }
-//            
-//        }).disposed(by: disposeBag)
-//    }
+        }).disposed(by: disposeBag)
+    }
+    
+    // MARK: - 버튼 바인딩
     
     private func bindViewEvents() {
         vocaMainView.buttonTapRelay.subscribe(onNext: { action in
@@ -64,25 +83,20 @@ final class VocaMainViewController: UIViewController {
                 self.present(self.vocaModalViewController, animated: true)
             }
         }).disposed(by: disposeBag)
-        
-    }
-}
-
-extension VocaMainViewController: UITableViewDataSource {
-    
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 2
     }
     
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "VocaMainTableViewCell") as? VocaMainTableViewCell else {
-            return UITableViewCell()
-        }
-        
-        cell.configureCell()
-        
-        return cell
+    // MARK: - 테이블뷰 바인딩
+    
+    private func bindTableView() {
+        vocaMainViewModel.vocaBookSubject
+            .observe(on: MainScheduler.instance)
+            .bind(to: vocaMainView.vocaTableView.rx.items(
+                cellIdentifier: VocaMainTableViewCell.id,
+                cellType: VocaMainTableViewCell.self
+            )) { row, element, cell in
+                cell.cardView.meanLabel.text = element.meaning
+                cell.cardView.wordLabel.text = element.word
+            }.disposed(by: disposeBag)
     }
 }
 

--- a/VocaVocca/ViewModel/Voca/VocaMainViewModel.swift
+++ b/VocaVocca/ViewModel/Voca/VocaMainViewModel.swift
@@ -39,14 +39,12 @@ class VocaMainViewModel {
             .subscribe(onNext: { [weak self] vocaBookData in
                 
                 //TODO: 단어선택화면 구현시 수정 예정
-                let voca = vocaBookData.first!
+                guard let voca = vocaBookData.first else { return }
                 
                 if let wordsSet = voca.words as? Set<VocaData> {
                     let array = Array(wordsSet)
                     
                     self?.vocaBookSubject.onNext(array)
-                    
-                    
                 }
                 
             },onError: { error in

--- a/VocaVocca/ViewModel/Voca/VocaMainViewModel.swift
+++ b/VocaVocca/ViewModel/Voca/VocaMainViewModel.swift
@@ -14,34 +14,39 @@ class VocaMainViewModel {
     private var currentVocaBookId = UUID()
     private let coreData = CoreDataManager.shared
     private let disposeBag = DisposeBag()
+    private let manager = UserDefaultsManager()
     
-    let vocaBookSubject = BehaviorSubject(value: VocaBookData())
+    let vocaBookSubject = BehaviorSubject(value: [VocaData]())
     
     init() {
-        fetchVocaBookId()
+//        fetchVocaBookId()
         fetchVocaBook()
     }
-
+    
+    // MARK: - 단어장 ID 조회
+    
     private func fetchVocaBookId() {
-        if let uuidString = UserDefaults.standard.string(forKey: "chosenVocaBook"),
+        if let uuidString = manager.getVocaBookID(),
            let uuid = UUID(uuidString: uuidString) {
-            print("uuid: \(uuid)")
             currentVocaBookId = uuid
         }
     }
+    
+    // MARK: - 단어 조회
     
     private func fetchVocaBook() {
         coreData.fetchVocaBookData()
             .subscribe(onNext: { [weak self] vocaBookData in
                 
-                guard let uuid = self?.currentVocaBookId else { return }
+                //TODO: 단어선택화면 구현시 수정 예정
+                let voca = vocaBookData.first!
                 
-                for data in vocaBookData {
-                    if data.id == uuid {
-                        self?.vocaBookSubject.onNext(data)
-                        
-                        return
-                    }
+                if let wordsSet = voca.words as? Set<VocaData> {
+                    let array = Array(wordsSet)
+                    
+                    self?.vocaBookSubject.onNext(array)
+                    
+                    
                 }
                 
             },onError: { error in

--- a/VocaVocca/ViewModel/Voca/VocaModalViewModel.swift
+++ b/VocaVocca/ViewModel/Voca/VocaModalViewModel.swift
@@ -88,14 +88,12 @@ class VocaModalViewModel {
     func fetchVocaBookFromCoreData () {
         testVocaBook()
             .subscribe(onCompleted: {
-                print("444")
             }, onError: { error in
                 print(error)
             }).disposed(by: disposeBag)
         coreDataManager.fetchVocaBookData()
             .subscribe(onNext: { [weak self] vocaBookData in
                 self?.testData = vocaBookData
-                print("222", vocaBookData)
             }, onError: { error in
                 print(error)
             }).disposed(by: disposeBag)


### PR DESCRIPTION
### 📝 작업 내용
  - 메인화면 UI 수정
  - UserDefaultsManager 수정

### 🚀 주요 변경 사항
- 메인화면 UITableVIewCell을 coreData 연결
- 메인화면 카드 뷰에 삭제버튼, 태그 추가
- UserDefaultsManager에 선택한 단어장 조회 및 생성 함수 추가

### 📷 스크린샷
<img width="400" alt="" src="https://github.com/user-attachments/assets/f8e5dcd4-67f3-4f51-a6c4-60910c7af58d" />

### 💡 추가 계획
  - 단어 삭제 버튼 기능 구현
  - 단어장 선택시 메인화면에 데이터 반영하는 기능
  - 카드뷰 태그 라벨 변경 기능