### PR TITLE
[#80] ViewModel 데이터 바인딩 및 컨트롤러 연동 구현

### DIFF
--- a/VocaVocca/View/Record/RecordResultViewController.swift
+++ b/VocaVocca/View/Record/RecordResultViewController.swift
@@ -16,20 +16,21 @@ final class RecordResultViewController: UIViewController {
     private let correctWordsView = RecordResultView()
     private let incorrectWordsView = RecordResultView()
     private let disposeBag = DisposeBag()
+    private let viewModel: RecordResultViewModel
     
-    // 테스트 더미 데이터
-    private let dummyCorrectWords = [("apple", "사과"), ("banana", "바나나"), ("cherry", "체리"), ("date", "대추"), ("elderberry", "엘더베리")]
-    private let dummyIncorrectWords = [("fig", "무화과"), ("grape", "포도"), ("honeydew", "허니듀"), ("kiwi", "키위"), ("lemon", "레몬")]
+    init(viewModel: RecordResultViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
     
-    // 데이터 소스
-    private let correctWords = BehaviorRelay<[(String, String)]>(value: [])
-    private let incorrectWords = BehaviorRelay<[(String, String)]>(value: [])
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setup()
         bindTableView()
-        loadDummyData() // 더미 데이터 로드
     }
     
     private func setup() {
@@ -54,8 +55,8 @@ final class RecordResultViewController: UIViewController {
     }
     
     private func bindTableView() {
-        // CorrectWordsView 테이블 뷰 바인딩
-        correctWords
+        // CorrectWordsView 바인딩
+        viewModel.correctWords
             .bind(to: correctWordsView.tableView.rx.items(cellIdentifier: RecordResultViewCell.id, cellType: RecordResultViewCell.self)) { _, wordPair, cell in
                 let (word, meaning) = wordPair
                 cell.configureCell(isCorrect: true)
@@ -64,8 +65,8 @@ final class RecordResultViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
-        // IncorrectWordsView 테이블 뷰 바인딩
-        incorrectWords
+        // IncorrectWordsView 바인딩
+        viewModel.incorrectWords
             .bind(to: incorrectWordsView.tableView.rx.items(cellIdentifier: RecordResultViewCell.id, cellType: RecordResultViewCell.self)) { _, wordPair, cell in
                 let (word, meaning) = wordPair
                 cell.configureCell(isCorrect: false)
@@ -75,19 +76,13 @@ final class RecordResultViewController: UIViewController {
             .disposed(by: disposeBag)
     }
     
-    private func loadDummyData() {
-        // 더미 데이터 설정
-        correctWords.accept(dummyCorrectWords)
-        incorrectWords.accept(dummyIncorrectWords)
-    }
-    
     func showCorrectWords() {
-        self.correctWordsView.isHidden = false
-        self.incorrectWordsView.isHidden = true
+        correctWordsView.isHidden = false
+        incorrectWordsView.isHidden = true
     }
     
     func showIncorrectWords() {
-        self.correctWordsView.isHidden = true
-        self.incorrectWordsView.isHidden = false
+        correctWordsView.isHidden = true
+        incorrectWordsView.isHidden = false
     }
 }

--- a/VocaVocca/View/Record/RecordResultViewController.swift
+++ b/VocaVocca/View/Record/RecordResultViewController.swift
@@ -16,10 +16,13 @@ final class RecordResultViewController: UIViewController {
     private let correctWordsView = RecordResultView()
     private let incorrectWordsView = RecordResultView()
     private let disposeBag = DisposeBag()
-    private let viewModel: RecordResultViewModel
     
-    init(viewModel: RecordResultViewModel) {
-        self.viewModel = viewModel
+    let correctWords: Observable<[(String, String)]>
+    let incorrectWords: Observable<[(String, String)]>
+    
+    init(correctWords: Observable<[(String, String)]>, incorrectWords: Observable<[(String, String)]>) {
+        self.correctWords = correctWords
+        self.incorrectWords = incorrectWords
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -56,7 +59,7 @@ final class RecordResultViewController: UIViewController {
     
     private func bindTableView() {
         // CorrectWordsView 바인딩
-        viewModel.correctWords
+        correctWords
             .bind(to: correctWordsView.tableView.rx.items(cellIdentifier: RecordResultViewCell.id, cellType: RecordResultViewCell.self)) { _, wordPair, cell in
                 let (word, meaning) = wordPair
                 cell.configureCell(isCorrect: true)
@@ -66,7 +69,7 @@ final class RecordResultViewController: UIViewController {
             .disposed(by: disposeBag)
         
         // IncorrectWordsView 바인딩
-        viewModel.incorrectWords
+        incorrectWords
             .bind(to: incorrectWordsView.tableView.rx.items(cellIdentifier: RecordResultViewCell.id, cellType: RecordResultViewCell.self)) { _, wordPair, cell in
                 let (word, meaning) = wordPair
                 cell.configureCell(isCorrect: false)

--- a/VocaVocca/View/Record/RecordResultViewController.swift
+++ b/VocaVocca/View/Record/RecordResultViewController.swift
@@ -79,10 +79,12 @@ final class RecordResultViewController: UIViewController {
     func showCorrectWords() {
         correctWordsView.isHidden = false
         incorrectWordsView.isHidden = true
+        title = "암기한 단어"
     }
     
     func showIncorrectWords() {
         correctWordsView.isHidden = true
         incorrectWordsView.isHidden = false
+        title = "틀린 단어"
     }
 }

--- a/VocaVocca/View/Record/RecordView.swift
+++ b/VocaVocca/View/Record/RecordView.swift
@@ -27,11 +27,10 @@ final class RecordView: UIView {
         return label
     }()
     
-    private let correctCountLabel: UILabel = {
+    let correctCountLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 44, weight: .bold)
         label.textAlignment = .center
-        label.text = "15"
         label.textColor = .systemBlue
         return label
     }()
@@ -53,11 +52,10 @@ final class RecordView: UIView {
         return label
     }()
     
-    private let incorrectCountLabel: UILabel = {
+    let incorrectCountLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 44, weight: .bold)
         label.textAlignment = .center
-        label.text = "15"
         label.textColor = .systemRed
         return label
     }()

--- a/VocaVocca/View/Record/RecordViewController.swift
+++ b/VocaVocca/View/Record/RecordViewController.swift
@@ -25,9 +25,6 @@ final class RecordViewController: UIViewController {
         setupActions()
         setUpNaviBar()
         
-        // 오늘 학습 기록 불러오기
-        viewModel.fetchTodayRecords()
-        
         // 데이터 바인딩 확인
         viewModel.todayCorrectWords
             .map { "\($0.count)" }
@@ -65,8 +62,10 @@ final class RecordViewController: UIViewController {
         recordView.correctButton.rx.tap
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
-                let resultVM = RecordResultViewModel(recordViewModel: self.viewModel)
-                let resultVC = RecordResultViewController(viewModel: resultVM)
+                let resultVC = RecordResultViewController(
+                    correctWords: self.viewModel.todayCorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "") } },
+                    incorrectWords: self.viewModel.todayIncorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "") } }
+                )
                 resultVC.showCorrectWords()
                 self.navigationController?.pushViewController(resultVC, animated: true)
             })
@@ -76,8 +75,10 @@ final class RecordViewController: UIViewController {
         recordView.incorrectButton.rx.tap
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
-                let resultVM = RecordResultViewModel(recordViewModel: self.viewModel)
-                let resultVC = RecordResultViewController(viewModel: resultVM)
+                let resultVC = RecordResultViewController(
+                    correctWords: self.viewModel.todayCorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "") } },
+                    incorrectWords: self.viewModel.todayIncorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "") } }
+                )
                 resultVC.showIncorrectWords()
                 self.navigationController?.pushViewController(resultVC, animated: true)
             })

--- a/VocaVocca/View/Record/RecordViewController.swift
+++ b/VocaVocca/View/Record/RecordViewController.swift
@@ -14,6 +14,7 @@ final class RecordViewController: UIViewController {
     
     private let recordView = RecordView()
     private let disposeBag = DisposeBag()
+    private let viewModel = RecordViewModel()
     
     override func loadView() {
         view = recordView
@@ -23,9 +24,29 @@ final class RecordViewController: UIViewController {
         super.viewDidLoad()
         setupActions()
         setUpNaviBar()
+        
+        // 오늘 학습 기록 불러오기
+        viewModel.fetchTodayRecords()
+        
+        // 데이터 바인딩 확인
+        viewModel.todayCorrectWords
+            .map { "\($0.count)" }
+            .bind(to: recordView.correctCountLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        viewModel.todayIncorrectWords
+            .map { "\($0.count)" }
+            .bind(to: recordView.incorrectCountLabel.rx.text)
+            .disposed(by: disposeBag)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.fetchTodayRecords()
     }
     
     private func setUpNaviBar() {
+        
         title = "학습 기록"
         
         let appearance = UINavigationBarAppearance()
@@ -44,7 +65,8 @@ final class RecordViewController: UIViewController {
         recordView.correctButton.rx.tap
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
-                let resultVC = RecordResultViewController()
+                let resultVM = RecordResultViewModel(recordViewModel: self.viewModel)
+                let resultVC = RecordResultViewController(viewModel: resultVM)
                 resultVC.showCorrectWords()
                 self.navigationController?.pushViewController(resultVC, animated: true)
             })
@@ -54,7 +76,8 @@ final class RecordViewController: UIViewController {
         recordView.incorrectButton.rx.tap
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
-                let resultVC = RecordResultViewController()
+                let resultVM = RecordResultViewModel(recordViewModel: self.viewModel)
+                let resultVC = RecordResultViewController(viewModel: resultVM)
                 resultVC.showIncorrectWords()
                 self.navigationController?.pushViewController(resultVC, animated: true)
             })

--- a/VocaVocca/ViewModel/Record/RecordResultViewModel.swift
+++ b/VocaVocca/ViewModel/Record/RecordResultViewModel.swift
@@ -6,3 +6,26 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
+
+final class RecordResultViewModel {
+    
+    let correctWords: BehaviorRelay<[(String, String)]> = BehaviorRelay(value: [])
+    let incorrectWords: BehaviorRelay<[(String, String)]> = BehaviorRelay(value: [])
+    
+    private let disposeBag = DisposeBag()
+    
+    init(recordViewModel: RecordViewModel) {
+        // RecordViewModel에서 데이터를 가져옴
+        recordViewModel.todayCorrectWords
+            .map { $0.map { ($0.word ?? "", $0.meaning ?? "") } }
+            .bind(to: correctWords)
+            .disposed(by: disposeBag)
+        
+        recordViewModel.todayIncorrectWords
+            .map { $0.map { ($0.word ?? "", $0.meaning ?? "") } }
+            .bind(to: incorrectWords)
+            .disposed(by: disposeBag)
+    }
+}

--- a/VocaVocca/ViewModel/Record/RecordViewModel.swift
+++ b/VocaVocca/ViewModel/Record/RecordViewModel.swift
@@ -6,3 +6,46 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
+
+final class RecordViewModel {
+    
+    private let disposeBag = DisposeBag()
+    private let coreDataManager = CoreDataManager.shared
+    
+    // 오늘 암기한 단어와 틀린 단어를 각각 저장할 BehaviorRelay
+    let todayCorrectWords = BehaviorRelay<[VocaData]>(value: [])
+    let todayIncorrectWords = BehaviorRelay<[VocaData]>(value: [])
+    
+    func fetchTodayRecords() {
+        coreDataManager.fetchRecordData()
+            .subscribe(onNext: { [weak self] records in
+                guard let self = self else { return }
+                
+                // 오늘 날짜 기준으로 필터링
+                let today = Calendar.current.startOfDay(for: Date())
+                
+                let filteredRecords = records.filter { record in
+                    guard let recordDate = record.date else { return false }
+                    return Calendar.current.isDate(recordDate, inSameDayAs: today)
+                }
+                
+                // 암기한 단어와 틀린 단어로 분리
+                let correctWords = filteredRecords
+                    .filter { $0.iscorrected }
+                    .compactMap { $0.voca }
+                
+                let incorrectWords = filteredRecords
+                    .filter { !$0.iscorrected }
+                    .compactMap { $0.voca }
+                
+                // BehaviorRelay에 데이터 전달
+                self.todayCorrectWords.accept(correctWords)
+                self.todayIncorrectWords.accept(incorrectWords)
+            }, onError: { error in
+                print("Error fetching records: \(error)")
+            })
+            .disposed(by: disposeBag)
+    }
+}


### PR DESCRIPTION
### 📝 작업 내용
  - RecordViewModel에서 학습 기록 데이터 불러오기 구현
  - RecordViewController와 RecordResultViewController에서 ViewModel과 데이터 바인딩 구현
  - 학습 기록 화면과 상세 결과 하면 간의 네비게이션 로직 추가

### 🚀 주요 변경 사항
- 오늘 학습한 정답/오답 단어 수를 RecordViewController에서 실시간으로 표시
- RecordResultViewController에서 정답/오답 단어 목록 테이블 뷰 바인딩
- Correct/Incorrect 버튼 클릭 시 상세 결과 화면으로 이동

### 📷 스크린샷

https://github.com/user-attachments/assets/58df22d8-65da-45c1-8739-7debb19ff90d


