### PR TITLE
[#85] 선택 에러 시, 토스트 메세지 기능 구현

### DIFF
--- a/VocaVocca/View/Learning/LearningView.swift
+++ b/VocaVocca/View/Learning/LearningView.swift
@@ -33,6 +33,22 @@ final class LearningView: UIView {
         return button
     }()
     
+    let toastView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .black.withAlphaComponent(0.7)
+        view.layer.cornerRadius = 15
+        view.isHidden = true
+        return view
+    }()
+
+    let toastLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = UIFont.systemFont(ofSize: 15)
+        label.sizeToFit()
+        return label
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .white
@@ -44,7 +60,9 @@ final class LearningView: UIView {
     }
     
     private func setupUI() {
-        addSubviews(collectionView, startButton)
+        addSubviews(collectionView, startButton, toastView)
+        
+        toastView.addSubview(toastLabel)
         
         collectionView.snp.makeConstraints {
             $0.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
@@ -57,6 +75,17 @@ final class LearningView: UIView {
             $0.horizontalEdges.equalToSuperview().inset(40)
             $0.height.equalTo(60)
             $0.centerX.equalToSuperview()
+        }
+        
+        toastView.snp.makeConstraints {
+            $0.width.equalTo(toastLabel.snp.width).multipliedBy(1.5)
+            $0.height.equalTo(toastLabel.snp.height).multipliedBy(2)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(200)
+        }
+        
+        toastLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
         }
     }
 }

--- a/VocaVocca/ViewModel/Learning/LearningViewModel.swift
+++ b/VocaVocca/ViewModel/Learning/LearningViewModel.swift
@@ -9,21 +9,52 @@ import UIKit
 import RxSwift
 import RxCocoa
 
+enum SelectionError {
+    case noSelect
+    case noVoca
+    
+    var text: String {
+        switch self {
+        case .noSelect:
+            return "단어장을 선택해주세요."
+        case .noVoca:
+            return "단어장에 단어가 없습니다."
+        }
+    }
+}
+
 class LearningViewModel {
     
     private let disposeBag = DisposeBag()
     
     let vocaBookSubject = BehaviorSubject(value: [VocaBookData]())
     var selectedVocaBook: VocaBookData?
-    
+    let vocaBookSelectionError = BehaviorSubject(value: SelectionError.noSelect)
+    let navigateToFlashCard = PublishSubject<VocaBookData>()
     var data = [VocaBookData]()
     
     init () {
         fetchVocaBookFromCoreData()
     }
     
-    // 단어장의 단어 개수를 확인해 이동 가능 여부를 반환
-    func checkWordsCount() -> Bool {
+    // 보카북 상태 확인
+    func handleVocaBookSelection() {
+        // 선택된 보카북이 없으면 noSelect 방출
+        guard let selectedBook = selectedVocaBook else {
+            vocaBookSelectionError.onNext(SelectionError.noSelect)
+            return
+        }
+        // 단어가 있는지 확인
+        if hasWordsInVocaBook() {
+            navigateToFlashCard.onNext(selectedBook)
+        } else {
+            vocaBookSelectionError.onNext(SelectionError.noVoca)
+
+        }
+    }
+    
+    // 단어장에 단어가 있는지 확인
+    func hasWordsInVocaBook() -> Bool {
         guard let selectedBook = selectedVocaBook else { return false }
         return selectedBook.words?.count ?? 0 > 0
     }


### PR DESCRIPTION
### 📝 작업 내용
단어장을 선택하지 않거나 단어장에 단어가 없을 경우 토스트 메세지를 보여주는 기능을 구현했습니다.

### 🚀 주요 변경 사항
- `handleVocaBookSelection`에서 상태 확인
- `vocaBookSelectionError`에서 선택 에러 방출
- `navigateToFlashCard`에서 `vocaBookData` 방출

### 📷 스크린샷
![Simulator Screen Recording - iPhone 16 Pro - 2025-01-14 at 20 11 24](https://github.com/user-attachments/assets/87caa60d-6cda-4a22-b886-86fdbd70a28c)
