### PR TITLE
[#94] 셀 선택 스타일 제거 및 화면 전환 애니메이션 개선

### DIFF
--- a/VocaVocca/View/Record/RecordResultViewController.swift
+++ b/VocaVocca/View/Record/RecordResultViewController.swift
@@ -36,6 +36,20 @@ final class RecordResultViewController: UIViewController {
         bindTableView()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        // 화면 전환을 자연스럽게 만들기 위한 CATransition 사용
+        let transition = CATransition()
+        transition.duration = 0.3
+        transition.type = .push
+        transition.subtype = .fromLeft
+        transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        
+        navigationController?.view.layer.add(transition, forKey: kCATransition)
+        navigationController?.popViewController(animated: false) // 기본 애니메이션 비활성화
+    }
+    
     private func setup() {
         view.backgroundColor = .white
         
@@ -65,6 +79,7 @@ final class RecordResultViewController: UIViewController {
                 cell.configureCell(isCorrect: true)
                 cell.cardView.wordLabel.text = word
                 cell.cardView.meanLabel.text = meaning
+                cell.selectionStyle = .none
             }
             .disposed(by: disposeBag)
         
@@ -75,6 +90,7 @@ final class RecordResultViewController: UIViewController {
                 cell.configureCell(isCorrect: false)
                 cell.cardView.wordLabel.text = word
                 cell.cardView.meanLabel.text = meaning
+                cell.selectionStyle = .none
             }
             .disposed(by: disposeBag)
     }

--- a/VocaVocca/View/Record/RecordView.swift
+++ b/VocaVocca/View/Record/RecordView.swift
@@ -76,7 +76,7 @@ final class RecordView: UIView {
         
         correctButton.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(30)
-            $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).offset(80)
+            $0.centerY.equalToSuperview().offset(-100)
             $0.height.equalTo(160)
         }
         

--- a/VocaVocca/ViewModel/Record/RecordResultViewModel.swift
+++ b/VocaVocca/ViewModel/Record/RecordResultViewModel.swift
@@ -11,21 +11,11 @@ import RxCocoa
 
 final class RecordResultViewModel {
     
-    let correctWords: BehaviorRelay<[(String, String)]> = BehaviorRelay(value: [])
-    let incorrectWords: BehaviorRelay<[(String, String)]> = BehaviorRelay(value: [])
+    let correctWords: Observable<[(String, String)]>
+    let incorrectWords: Observable<[(String, String)]>
     
-    private let disposeBag = DisposeBag()
-    
-    init(recordViewModel: RecordViewModel) {
-        // RecordViewModel에서 데이터를 가져옴
-        recordViewModel.todayCorrectWords
-            .map { $0.map { ($0.word ?? "", $0.meaning ?? "") } }
-            .bind(to: correctWords)
-            .disposed(by: disposeBag)
-        
-        recordViewModel.todayIncorrectWords
-            .map { $0.map { ($0.word ?? "", $0.meaning ?? "") } }
-            .bind(to: incorrectWords)
-            .disposed(by: disposeBag)
+    init(correctWords: Observable<[(String, String)]>, incorrectWords: Observable<[(String, String)]>) {
+        self.correctWords = correctWords
+        self.incorrectWords = incorrectWords
     }
 }


### PR DESCRIPTION
### 📝 작업 내용
  - RecordResultViewController에 화면 전환 애니메이션 추가 (CATransition 적용).
  - 셀 선택 시 회색 배경 제거 (selectionStyle = .none 적용).
  - 학습 기록 화면 셀 위치 가운데로 설정.
  - RecordResultViewModel 생성자 수정: 뷰모델 자체를 전달하지 않고 필요한 데이터만 전달받고록 구조를 개선.

### 🚀 주요 변경 사항
- 화면 전환 애니메이션 개선: viewWillDisappear에서 CATransition을 활용하여 전환.
- UI 개선: 셀 선택 시 나타나는 기본 회색 배경 제거
- 뷰모델 구조 개선: RecordResultViewModel이 데이터를 Observable로 주입받도록 수정하여 데이터 전달

### 📷 스크린샷

https://github.com/user-attachments/assets/8b54c851-e957-46ff-bbda-3c4b9221839a



