### PR TITLE
[#106] 해당 단어에 언어 정보를 태그 형태로 표시

### DIFF
--- a/VocaVocca/View/Record/RecordResultViewController.swift
+++ b/VocaVocca/View/Record/RecordResultViewController.swift
@@ -17,10 +17,10 @@ final class RecordResultViewController: UIViewController {
     private let incorrectWordsView = RecordResultView()
     private let disposeBag = DisposeBag()
     
-    let correctWords: Observable<[(String, String)]>
-    let incorrectWords: Observable<[(String, String)]>
+    let correctWords: Observable<[(String, String, String)]>
+    let incorrectWords: Observable<[(String, String, String)]>
     
-    init(correctWords: Observable<[(String, String)]>, incorrectWords: Observable<[(String, String)]>) {
+    init(correctWords: Observable<[(String, String, String)]>, incorrectWords: Observable<[(String, String, String)]>) {
         self.correctWords = correctWords
         self.incorrectWords = incorrectWords
         super.init(nibName: nil, bundle: nil)
@@ -75,10 +75,11 @@ final class RecordResultViewController: UIViewController {
         // CorrectWordsView 바인딩
         correctWords
             .bind(to: correctWordsView.tableView.rx.items(cellIdentifier: RecordResultViewCell.id, cellType: RecordResultViewCell.self)) { _, wordPair, cell in
-                let (word, meaning) = wordPair
+                let (word, meaning, lanaguage) = wordPair
                 cell.configureCell(isCorrect: true)
                 cell.cardView.wordLabel.text = word
                 cell.cardView.meanLabel.text = meaning
+                cell.languageTag.setTagView(layerColor: .systemGray2, label: lanaguage, textColor: .white)
                 cell.selectionStyle = .none
             }
             .disposed(by: disposeBag)
@@ -86,10 +87,11 @@ final class RecordResultViewController: UIViewController {
         // IncorrectWordsView 바인딩
         incorrectWords
             .bind(to: incorrectWordsView.tableView.rx.items(cellIdentifier: RecordResultViewCell.id, cellType: RecordResultViewCell.self)) { _, wordPair, cell in
-                let (word, meaning) = wordPair
+                let (word, meaning, lanaguage) = wordPair
                 cell.configureCell(isCorrect: false)
                 cell.cardView.wordLabel.text = word
                 cell.cardView.meanLabel.text = meaning
+                cell.languageTag.setTagView(layerColor: .red, label: lanaguage, textColor: .white)
                 cell.selectionStyle = .none
             }
             .disposed(by: disposeBag)

--- a/VocaVocca/View/Record/RecordViewController.swift
+++ b/VocaVocca/View/Record/RecordViewController.swift
@@ -63,8 +63,8 @@ final class RecordViewController: UIViewController {
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
                 let resultVC = RecordResultViewController(
-                    correctWords: self.viewModel.todayCorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "") } },
-                    incorrectWords: self.viewModel.todayIncorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "") } }
+                    correctWords: self.viewModel.todayCorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "", $0.books?.language ?? "언어") } },
+                    incorrectWords: self.viewModel.todayIncorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "", $0.books?.language ?? "언어") } }
                 )
                 resultVC.showCorrectWords()
                 self.navigationController?.pushViewController(resultVC, animated: true)
@@ -76,8 +76,8 @@ final class RecordViewController: UIViewController {
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
                 let resultVC = RecordResultViewController(
-                    correctWords: self.viewModel.todayCorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "") } },
-                    incorrectWords: self.viewModel.todayIncorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "") } }
+                    correctWords: self.viewModel.todayCorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "", $0.books?.language ?? "언어") } },
+                    incorrectWords: self.viewModel.todayIncorrectWords.map { $0.map { ($0.word ?? "", $0.meaning ?? "", $0.books?.language ?? "언어") } }
                 )
                 resultVC.showIncorrectWords()
                 self.navigationController?.pushViewController(resultVC, animated: true)

--- a/VocaVocca/ViewModel/Record/RecordResultViewModel.swift
+++ b/VocaVocca/ViewModel/Record/RecordResultViewModel.swift
@@ -11,10 +11,10 @@ import RxCocoa
 
 final class RecordResultViewModel {
     
-    let correctWords: Observable<[(String, String)]>
-    let incorrectWords: Observable<[(String, String)]>
+    let correctWords: Observable<[(String, String, String)]>
+    let incorrectWords: Observable<[(String, String, String)]>
     
-    init(correctWords: Observable<[(String, String)]>, incorrectWords: Observable<[(String, String)]>) {
+    init(correctWords: Observable<[(String, String, String)]>, incorrectWords: Observable<[(String, String, String)]>) {
         self.correctWords = correctWords
         self.incorrectWords = incorrectWords
     }


### PR DESCRIPTION
### 📝 작업 내용
  - RecordResultViewController에서 맞은 단어와 틀린 단어 목록에 언어 태그 표시 기능 수정
  - RecordViewController에서 RecordResultViewController로 데이터 전달 시 언어 정보 포함하도록 수정

### 🚀 주요 변경 사항
- RecordResultViewController 및 RecordViewModel 데이터 구조 수정: (String, String, String) 형식으로 변경
- bindTableView 메서드에서 언어 태그 설정 로직 추가

### 📷 스크린샷

<img width="400" alt="" src="https://github.com/user-attachments/assets/566a7974-db15-47f5-be3b-ec5fe21f38b2" />


